### PR TITLE
Update Node.js version from 18.x to 22.x

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
       - run: npm ci
       #- run: npm test
 
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - id: publish

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,2 +1,2 @@
-lts/hydrogen
+lts/jod
 #18.19.0

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
 
 MIT License
 
-Copyright (c) 2022 - 2024 @BigThunderSR
+Copyright (c) 2022 - 2025 @BigThunderSR
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "nyc": "^17.1.0"
       },
       "engines": {
-        "node": ">=14.21.3"
+        "node": ">=18.20.6"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "uuid": "^11.1.0"
   },
   "node-red": {
-    "version": ">=3.0.0",
+    "version": ">=4.0.9",
     "nodes": {
       "onstar": "onstar.js"
     }
   },
   "engines": {
-    "node": ">=14.21.3"
+    "node": ">=18.20.6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request includes updates to the Node.js version, license, and package dependencies. The most important changes include updating the Node.js version in various configuration files, modifying the license year, and updating the Node-RED and engine versions in `package.json`.

### Node.js Version Updates:

* [`.github/workflows/npm-publish.yml`](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240L17-R17): Updated the Node.js version from `18.x` to `22.x` in the GitHub Actions workflow. [[1]](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240L17-R17) [[2]](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240L30-R30)
* [`.nvmrc`](diffhunk://#diff-2c8effdf840690ccb88c7e21e56148978c6adb2c6926530c58ff0e47a9588b44L1-R1): Changed the Node.js version from `lts/hydrogen` to `lts/jod`.

### License Update:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L5-R5): Updated the license year from 2024 to 2025.

### Package Dependency Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-R23): Updated the Node-RED version requirement from `>=3.0.0` to `>=4.0.9` and the Node.js engine version from `>=14.21.3` to `>=18.20.6`.