### PR TITLE
Add optional token location field to OnStar configuration

### DIFF
--- a/onstar.html
+++ b/onstar.html
@@ -564,6 +564,7 @@
             pin: { required: true, validate: RED.validators.number() },
             vin: { required: true },
             deviceid: { required: true },
+            tokenlocation: { value: '', required: false },
             checkrequeststatus: { value: true, required: true },
             requestpollingtimeoutseconds: { value: 90, required: true, validate: RED.validators.number() },
             requestpollingintervalseconds: { value: 6, required: true, validate: RED.validators.number() }
@@ -940,6 +941,10 @@
     <div class="form-row">
         <label for="node-config-input-deviceid"><i class="icon-bookmark"></i> Device ID (any valid V4 UUID)</label>
         <input type="text" id="node-config-input-deviceid" />
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-tokenlocation"><i class="icon-bookmark"></i> Token Location (Optional)</label>
+        <input type="text" id="node-config-input-tokenlocation" placeholder="Path to store token files" />
     </div>
     <div class="form-row">
         <label for="node-config-input-checkrequeststatus"><i class="icon-bookmark"></i> Set checkRequestStatus Value for OnStarJS</label>

--- a/onstar.js
+++ b/onstar.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const Vehicle = require('./deps/vehicle');
 
 function createClient(configNode) {
-    return OnStar.create({
+    let options = {
         username: configNode.username,
         password: configNode.password,
         vin: configNode.vin,
@@ -14,7 +14,14 @@ function createClient(configNode) {
         checkRequestStatus: configNode.checkrequeststatus,
         requestPollingTimeoutSeconds: configNode.requestpollingtimeoutseconds,
         requestPollingIntervalSeconds: configNode.requestpollingintervalseconds
-    });
+    };
+
+    // Add tokenLocation if configured
+    if (configNode.tokenlocation && configNode.tokenlocation.trim() !== '') {
+        options.tokenLocation = configNode.tokenlocation.trim();
+    }
+
+    return OnStar.create(options);
 }
 
 module.exports = function(RED) {
@@ -538,6 +545,7 @@ module.exports = function(RED) {
         this.pin = config.pin;
         this.vin = config.vin;
         this.deviceid = config.deviceid;
+        this.tokenlocation = config.tokenlocation;
         this.checkrequeststatus = config.checkrequeststatus;
         this.requestpollingtimeoutseconds = config.requestpollingtimeoutseconds;
         this.requestpollingintervalseconds = config.requestpollingintervalseconds;


### PR DESCRIPTION
Introduce an optional field for token location in the OnStar configuration, allowing users to specify a path for storing token files. Update the client creation logic to include this token location if provided.