### PR TITLE
fix: Remove breaking postinstall script from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "node-red-contrib-onstar2",
       "version": "2.6.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "onstar.js",
   "scripts": {
     "test": "nyc --exclude=\"deps/index.cjs\" --exclude=\"test\" mocha",
-    "test:auth": "RUN_AUTH_TESTS=true nyc --exclude=\"deps/index.cjs\" --exclude=\"test\" mocha test/authentication.spec.js",
-    "postinstall": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npx playwright install chromium --with-deps --force"
+    "test:auth": "RUN_AUTH_TESTS=true nyc --exclude=\"deps/index.cjs\" --exclude=\"test\" mocha test/authentication.spec.js"
   },
   "dependencies": {
     "axios": "^1.10.0",


### PR DESCRIPTION
The `postinstall` script has been removed, as it can cause installation issues.