### PR TITLE
security: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/auto-assign-issue.yaml
+++ b/.github/workflows/auto-assign-issue.yaml
@@ -11,7 +11,7 @@ jobs:
             issues: write
         steps:
             - name: 'Auto-assign issue'
-              uses: pozil/auto-assign-issue@v4
+              uses: pozil/auto-assign-issue@af6beea6bdf1e8eb373f061c5bc168681fc6d011 # v4
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   assignees: BigThunderSR

--- a/.github/workflows/auto-assign-pr.yaml
+++ b/.github/workflows/auto-assign-pr.yaml
@@ -11,7 +11,7 @@ jobs:
             pull-requests: write
         steps:
             - name: 'Auto-assign PR'
-              uses: pozil/auto-assign-issue@v4
+              uses: pozil/auto-assign-issue@af6beea6bdf1e8eb373f061c5bc168681fc6d011 # v4
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   assignees: BigThunderSR

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,11 +44,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.7
+      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -59,7 +59,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.37.7
+      uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -73,4 +73,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.7
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5

--- a/.github/workflows/node-install.yaml
+++ b/.github/workflows/node-install.yaml
@@ -31,11 +31,11 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         ref: ${{ github.event.workflow_run.head_branch }}
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -56,11 +56,11 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         ref: ${{ github.event.workflow_run.head_branch }}
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,16 +30,17 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         ref: ${{ github.event.workflow_run.head_branch }}
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
     - run: npm run check-pack
     - run: npm run check-deps
+    - run: npm run check-actions
     - run: npm run build --if-present
     #- run: npm test --if-present

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,8 +12,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24.x
       - run: npm ci
@@ -26,8 +26,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org/
@@ -38,7 +38,7 @@ jobs:
         #  NODE_AUTH_TOKEN: ${{secrets.npm_token}}        
       - if: steps.publish.outputs.type != 'none'
         name: Update Node-Red flow-library
-        uses: BigThunderSR/update-package-node-red-flow-library-action@v1.3.22
+        uses: BigThunderSR/update-package-node-red-flow-library-action@fc91472a9753be9717747eb4bb09e1e5396e087f # v1.3.22
         continue-on-error: true
         with:
           package-name: 'node-red-contrib-onstar2'

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
@@ -38,7 +38,7 @@ jobs:
       
       - name: Lint Code Base
         #uses: github/super-linter@v6
-        uses: super-linter/super-linter@v8
+        uses: super-linter/super-linter@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8
         env:
           VALIDATE_ALL_CODEBASE: true
           USE_FIND_ALGORITHM: true

--- a/.github/workflows/update-flow-library.yml
+++ b/.github/workflows/update-flow-library.yml
@@ -6,7 +6,7 @@ jobs:
   update-flow-library:
     runs-on: ubuntu-latest
     steps: 
-     - uses: BigThunderSR/update-package-node-red-flow-library-action@v1.3.22    
+     - uses: BigThunderSR/update-package-node-red-flow-library-action@fc91472a9753be9717747eb4bb09e1e5396e087f # v1.3.22    
        with:         
          package-name: 'node-red-contrib-onstar2'
          #delay-run-ms: 10000

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prepublishOnly": "npm run check-pack",
     "check-pack": "node scripts/check-pack.js",
     "check-deps": "node scripts/check-deep-imports.js",
+    "check-actions": "node scripts/check-action-pins.js",
     "test": "c8 --exclude=\"deps/index.cjs\" --exclude=\"test\" mocha --exclude test/real-api.spec.js",
     "test:auth": "c8 --exclude=\"deps/index.cjs\" --exclude=\"test\" mocha test/authentication.spec.js",
     "test:auth-legacy": "RUN_AUTH_TESTS=true c8 --exclude=\"deps/index.cjs\" --exclude=\"test\" mocha test/authentication.spec.js",

--- a/scripts/check-action-pins.js
+++ b/scripts/check-action-pins.js
@@ -1,0 +1,81 @@
+"use strict";
+
+// Verify every third-party GitHub Action in active workflows is pinned to a full 40-char commit SHA.
+
+const fs = require("fs");
+const path = require("path");
+
+const workflowsDir = path.join(__dirname, "..", ".github", "workflows");
+const SHA_RE = /^[0-9a-f]{40}$/;
+const USES_RE = /^\s*(?:-\s*)?uses:\s*([^\s#]+)/;
+
+function listWorkflowFiles() {
+    let entries;
+    try {
+        entries = fs.readdirSync(workflowsDir);
+    } catch {
+        return [];
+    }
+    return entries
+        .filter(name => name.endsWith(".yml") || name.endsWith(".yaml"))
+        .map(name => path.join(workflowsDir, name));
+}
+
+function findMutableRefs(filePath) {
+    const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
+    const violations = [];
+    lines.forEach((line, i) => {
+        if (/^\s*#/.test(line)) return;
+        const m = line.match(USES_RE);
+        if (!m) return;
+        const ref = m[1];
+        if (ref.startsWith("./") || ref.startsWith("docker://")) return;
+        const atIndex = ref.lastIndexOf("@");
+        if (atIndex === -1) return;
+        const version = ref.slice(atIndex + 1);
+        if (!SHA_RE.test(version)) {
+            violations.push({ line: i + 1, ref });
+        }
+    });
+    return violations;
+}
+
+const files = listWorkflowFiles();
+
+if (files.length === 0) {
+    console.log("No workflow files found under .github/workflows/.");
+    process.exit(0);
+}
+
+console.log(`Checking ${files.length} workflow file(s) for immutable action pins...\n`);
+
+let failed = 0;
+let passed = 0;
+
+for (const file of files.sort()) {
+    const rel = path.relative(path.join(__dirname, ".."), file);
+    const violations = findMutableRefs(file);
+    if (violations.length === 0) {
+        passed++;
+        continue;
+    }
+    for (const v of violations) {
+        console.error(`  \u2717 ${rel}:${v.line}`);
+        console.error(`    uses: ${v.ref}`);
+        failed++;
+    }
+}
+
+if (failed > 0) {
+    console.error(
+        `\n${failed} action reference(s) use a mutable tag or branch. ` +
+        "Pin each to a full 40-character commit SHA, keeping a trailing " +
+        "`# vX.Y.Z` comment so Dependabot/Renovate can still update it, e.g.:"
+    );
+    console.error(
+        "    uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7"
+    );
+    process.exit(1);
+} else {
+    console.log(`  All action references in ${passed} workflow file(s) are pinned to commit SHAs.`);
+}


### PR DESCRIPTION
Pin every third-party GitHub Action in active workflows to an immutable 40-character commit SHA to mitigate CI/CD supply-chain risk.

## Changes

- Pinned all third-party actions across 9 active workflow files to verified commit SHAs
- Each pinned line retains a `# vX.Y.Z` comment so Dependabot and Renovate can still propose updates
- Added `scripts/check-action-pins.js` CI guardrail (following existing `check-pack.js` / `check-deep-imports.js` conventions)
- Wired `npm run check-actions` into `node.js.yml` CI to enforce pinning going forward

## Pinned Actions

| Action | Pinned Version |
|--------|---------------|
| `actions/checkout` | v7 |
| `actions/setup-node` | v7 |
| `actions/dependency-review-action` | v5 |
| `github/codeql-action/{init,autobuild,analyze}` | v4.37.7 |
| `pozil/auto-assign-issue` | v4 |
| `super-linter/super-linter` | v8 |
| `BigThunderSR/update-package-node-red-flow-library-action` | v1.3.22 |

All SHAs verified against their respective tags via GitHub API.